### PR TITLE
Cache display of paths

### DIFF
--- a/ain/frames/explorer/explorer.py
+++ b/ain/frames/explorer/explorer.py
@@ -50,6 +50,8 @@ class Explorer(customtkinter.CTkFrame):
         self.pdf_viewer_frame = customtkinter.CTkFrame(self)
         self.pdf_viewer_frame.grid(row=3, sticky='ew')
 
+        self.filepath_display_cache = set()
+
     def browse(self):
         folder_path = filedialog.askdirectory(
             title='Select a directory to index')
@@ -59,9 +61,13 @@ class Explorer(customtkinter.CTkFrame):
 
     def list_pdfs(self):
         pdf_paths = find_pdfs_in(self.selected_dir)
+        new_paths = []
         for path in pdf_paths:
-            self.textbox.insert("end", path + "\n")
-        parse_pdfs(pdf_paths)
+            if path not in self.filepath_display_cache:
+                new_paths.append(path)
+                self.filepath_display_cache.add(path)
+                self.textbox.insert("end", path + "\n")
+        parse_pdfs(new_paths)
 
     def button_click2(self):
         print("button click")


### PR DESCRIPTION
## Overview
A fix to address the duplication of filepaths in the explorer window

## Issue Addressed
When the user clicks the ```Find PDFs``` button multiple times, the app displays previously shown filepaths multiple times.
![Screenshot 2023-12-25 171134](https://github.com/kaustavsarkar/geidetic/assets/79043865/6186eed2-2031-4971-a984-41f08df76090)

## Changes Done

I've added a ```set``` that gets initialized with the ```Explorer``` and maintains the list of filepaths that have already been displayed.

When the ```list_pdfs``` function is invoked, I've added a check to ensure that only the filepaths that are *not* present in the set mentioned above, are displayed in the text box


## The Impact

The ```Find PDFs``` button results in a unique filepath being listed only once
![image](https://github.com/kaustavsarkar/geidetic/assets/79043865/24ad6f52-69ee-4b17-90c4-4b2006af2282)
